### PR TITLE
fixes server crash

### DIFF
--- a/server/search.js
+++ b/server/search.js
@@ -71,7 +71,8 @@ module.exports = function(term) {
           }
         };
 
-        var url = types[type].url.replace('{term}', escape(term));
+        // ensure 'term' is encoded once and only once by decoding & re-encoding
+        var url = types[type].url.replace('{term}', encodeURIComponent(decodeURIComponent(term)));
 
         r(url, handle);
       });


### PR DESCRIPTION
Was playing around with this, and found that the node server crashed when searching for terms with spaces (e.g., "foo bar"). This seemed to be limited to Firefox; Chrome & Safari were ok, iirc. It seems the problem was that the search term was being double-encoded: Firefox was posting "foo%20bar", and that was getting further escaped to "foo%2520bar". This caused the YouTube query to not return `feed.entry`, so the `.map()` on line 13 of `server/searches.js` failed. 

Not sure if this is the best way to fix it (I'm just starting the climb up the JS learning curve), but it worked for me.

I didn't see existing tests for the node server code that I could add a test to, and adding that infrastructure was beyond me at this point.
